### PR TITLE
Bring back the boot prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ The ```-d <DISTRIB>``` switch is mostly for advanced users who want to install t
 ## Issues, Feedback
 
 Please report issues here : https://dev.yunohost.org/projects/yunohost/issues
+


### PR DESCRIPTION
I'm opening this to discuss whether or not the boot prompt from older YunoHost version should be reinstated. This prompt was part of the YunoHost installation: if you had installed your YunoHost server then this prompt would greet you at every boot. It can be seen on various pages across the doc, for example [here](https://yunohost.org/#/plug_and_boot). I think that's currently a problem since the doc is outdated... (Forgive me if this was only present on certain img/iso). 

So the idea is to display a handful of information concerninng the server and YunoHost installation, here's what it looks like: ![](https://framapic.org/DQ9iRBLN4G1x/i2LxUdYrT8dV)

The ugly ascii art act as a placeholder, until someone can come up with something cooler. What would be cool too is changing the ascii art for every big release, like an easter egg. If YunoHost is not installed then the version and domain won't be displayed, instead a prompt to proceed to the post installation will be here. The colors and info displayed can be easily modified, [here's the whole script](https://github.com/likeitneverwentaway/rpi_buildbot/blob/new/boot_prompt.sh), heavily adapted from [screenFetch](https://github.com/KittyKatt/screenFetch).

So here's how to install/test the boot prompt : 

- Get the script and the service : 
```
wget -q -P /usr/bin/ https://raw.githubusercontent.com/likeitneverwentaway/rpi_buildbot/new/boot_prompt.sh
wget -q -P /etc/systemd/system/ https://raw.githubusercontent.com/likeitneverwentaway/rpi_buildbot/new/boot_prompt.service
chmod a+x /usr/bin/boot_prompt.sh
```

- Enable the service:
`systemctl enable boot_prompt.service
`

Now if you reboot the server will wait for an internet connection, then display the prompt on the second virtual terminal.
Any thoughts and ideas ?