### PR TITLE
add apt-transport-https to dependencies

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -134,7 +134,7 @@ installscript_dependencies() {
       || return 1
     
     if is_raspbian ; then
-        DEPENDENCIES="ssl-cert lua-event lua-expat lua-socket lua-sec lua-filesystem"
+        DEPENDENCIES="ssl-cert lua-event lua-expat lua-socket lua-sec lua-filesystem apt-transport-https"
         apt_get_wrapper -o Dpkg::Options::="--force-confold" \
                         -y --force-yes install               \
                         $DEPENDENCIES                        \

--- a/install_yunohost
+++ b/install_yunohost
@@ -121,7 +121,7 @@ upgrade_system() {
 
 installscript_dependencies() {
     # dependencies of the install script itself
-    local DEPENDENCIES="lsb-release wget whiptail"
+    local DEPENDENCIES="lsb-release wget whiptail apt-transport-https"
 
     if [[ "$AUTOMODE" == "0" ]] ;
     then
@@ -134,7 +134,7 @@ installscript_dependencies() {
       || return 1
     
     if is_raspbian ; then
-        DEPENDENCIES="ssl-cert lua-event lua-expat lua-socket lua-sec lua-filesystem apt-transport-https"
+        DEPENDENCIES="ssl-cert lua-event lua-expat lua-socket lua-sec lua-filesystem"
         apt_get_wrapper -o Dpkg::Options::="--force-confold" \
                         -y --force-yes install               \
                         $DEPENDENCIES                        \


### PR DESCRIPTION
```bash
Les NOUVEAUX paquets suivants seront installés :
  lua-event lua-expat lua-filesystem lua-sec lua-socket ssl-cert
0 mis à jour, 6 nouvellement installés, 0 à enlever et 0 non mis à jour.
Il est nécessaire de prendre 163 ko dans les archives.
Après cette opération, 563 ko d'espace disque supplémentaires seront utilisés.
Réception de : 1 http://mirrordirector.raspbian.org/raspbian/ jessie/main lua-socket armhf 3.0~rc1-3 [88,0 kB]
Réception de : 2 http://mirrordirector.raspbian.org/raspbian/ jessie/main lua-event armhf 0.4.3-1 [14,2 kB]
Réception de : 3 http://mirrordirector.raspbian.org/raspbian/ jessie/main lua-expat armhf 1.3.0-2 [10,3 kB]
Réception de : 4 http://mirrordirector.raspbian.org/raspbian/ jessie/main lua-filesystem armhf 1.6.2-3 [9 666 B]
E: Le pilote pour la méthode /usr/lib/apt/methods/https n'a pu être trouvé.

Failure !
The following error was caught during Yunohost installation :

Unable to install dependencies to install script
```