### PR TITLE
Create web installation manual

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Installation script YunoHost</title>
+    <meta name="description" content="Installation script for YunoHost">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <style>
+      
+      pre code {
+        display: block;
+        background: #eee;
+        padding: 1em;
+      }
+      pre code:before {
+        content: "$ ";
+        display: inline;
+      }
+    </style>
+  </head>
+  <body>
+
+    <h1>YunoHost installation scripts</h1>
+
+    <section>
+      <h2>Context</h2>
+
+      <p>The script <code>install_yunohost</code> will install <a href="https://yunohost.org/">YunoHost</a> on a Debian system.</p>
+      <p>Only Debian 8 (aka Jessie) systems running with <a href="https://wiki.debian.org/systemd">systemd</a> - which is generally the default - are supported.</p>
+    </section>
+
+    <section>
+      <h2>Basic usage</h2>
+
+      <p>Go into a temporary folder, e.g. <code>/tmp</code>:</p>
+      <pre><code>cd /tmp</code></pre>
+      <p>Get the install script:</p>
+      <pre><code>wget https://install.yunohost.org/install_yunohost</code></pre>
+      <p>Execute the script:</p>
+      <pre><code>bash install_yunohost</code></pre>
+      <p>If something goes wrong, you can check the installation logs saved in <code>/var/log/yunohost-installation.log</code></p>
+    </section>
+
+    <section>
+      <h2>Advanced usage</h2>
+
+      <p>The script supports a number of positional arguments:</p>
+      <pre><code>bash install_yunohost -h
+      Usage :
+        install_yunohost [-a] [-d &lt;DISTRIB&gt;] [-h]
+
+      Options :
+        -a      Enable automatic mode. No questions are asked.
+                This does not perform the post-install step.
+        -d      Choose the distribution to install ('stable', 'testing', 'unstable').
+                Defaults to 'stable'
+        -h      Prints this help and exit
+      </code></pre>
+      <p>By specifying <code>-a</code>, the installation will be performed without asking any question.
+      This is useful for fully automated headless installations.
+      The <a href="https://yunohost.org/#/postinstall">post-installation</a> will need to be performed later.</p>
+      <p>The <code>-d &lt;DISTRIB&gt;</code> switch is mostly for advanced users who want to install the bleeding edge versions of YunoHost packages.</p>
+    </section>
+
+    <section>
+      <h2>Issues, Feedback</h2>
+
+      <p>Please report issues here : <a href="https://dev.yunohost.org/projects/yunohost/issues">https://dev.yunohost.org/projects/yunohost/issues</a></p>
+    </section>
+
+  </body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -25,13 +25,17 @@
         text-decoration: underline;
       }
 
+      h1,
+      h2 {
+        font-family: sans-serif;
+        line-height: 1.4;
+      }
+
       section {
         margin: 2em 0;
       }
 
       section h2 {
-        font-family: sans-serif;
-        line-height: 1.4;
         border-bottom: 1px solid #ddd;
       }
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
 
     <style>
       
+      body {
+        max-width: 50em;
+        margin: auto;
+      }
+
       pre code {
         display: block;
         background: #eee;

--- a/index.html
+++ b/index.html
@@ -11,11 +11,38 @@
       body {
         max-width: 50em;
         margin: auto;
+        color: #111;
+      }
+      ::-moz-selection { background: deeppink; color: white; }
+      ::selection { background: deeppink; color: white; }
+
+      a {
+        color: deeppink;
+        text-decoration: none;
+      }
+      a:hover,
+      a:focus {
+        text-decoration: underline;
+      }
+
+      section {
+        margin: 2em 0;
+      }
+
+      section h2 {
+        font-family: sans-serif;
+        line-height: 1.4;
+        border-bottom: 1px solid #ddd;
+      }
+
+      code {
+        display: inline-block;
+        background: #eee;
+        padding: 0.15em;
       }
 
       pre code {
         display: block;
-        background: #eee;
         padding: 1em;
       }
       pre code:before {


### PR DESCRIPTION
View it on https://install.yunohost.org/

Simple url easy to remember for both manual (https://install.yunohost.org/) and script (https://install.yunohost.org/install_yunohost)

- [ ] Add `install.sh` symlink to `install_yunohost` (even easier to remember)
- [ ] Add cron job that pull this repo on bearnaise container
- [ ] Clean README with link to install.yunohost.org and documentation page.