### PR TITLE
Install archivemount if fuse is present

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -284,6 +284,19 @@ install_yunohost_packages() {
         -o Dpkg::Options::="--force-confold" \
         -y --force-yes install               \
         yunohost yunohost-admin postfix
+        
+    # Install archivemount if fuse is present already
+    # (We do this because we cannot risk installing fuse ourselves because 
+    # install fails on some OpenVZ setups...
+    # see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=743360 )
+    if [ -e /dev/fuse ];
+    then
+        apt_get_wrapper \
+            -o Dpkg::Options::="--force-confold" \
+            -y --force-yes install               \
+            archivemount
+    fi
+    
 }
 
 restart_services() {


### PR DESCRIPTION
### Problem

See https://dev.yunohost.org/issues/942 : archivemount depends on fuse, which cannot be installed on some specific machines likes OpenVZ containers.

### Solution

Rather than trying to know if fuse can be installed on the system, it seems that it's already there on most setups because of other dependencies. So the proposed solution is to check if fuse seems already present (via `/dev/fuse`), and install archivemount if that's the case.

WARNING : Not tested yet !