### PR TITLE
[fix] Make /etc/resolv.conf mutable

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -278,6 +278,10 @@ install_yunohost_packages() {
     # Allow sudo removal even if no root password has been set (on some DO
     # droplet or Vagrant virtual machines), as YunoHost use sudo-ldap
     export SUDO_FORCE_REMOVE=yes
+    
+    # On some machines (e.g. OVH VPS), the /etc/resolv.conf is immutable
+    # We need to make it mutable for the resolvconf dependency to be installed
+    chattr -i /etc/resolv.conf 2>/dev/null || true
 
     # Install YunoHost
     apt_get_wrapper \


### PR DESCRIPTION
### Problem

C.f. https://dev.yunohost.org/issues/961 : two users recently reported that the install script failed because apparently OVH decided to put /etc/resolv.conf as 'immutable'.

Leading to the following message :

>resolvconf.postinst: Error: Cannot replace the current /etc/resolv.conf with a symbolic link because it is immutable; to correct this problem, gain root privileges in a terminal and run 'chattr -i /etc/resolv.conf' and then 'dpkg --configure resolvconf'; aborting

### Solution

Run `chattr -i /etc/resolv.conf` before installing Yunohost (which triggers the install of resolvconf).

