### PR TITLE
Handle Prosody installation and remove metronome relics

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -133,21 +133,6 @@ installscript_dependencies() {
                     $DEPENDENCIES                        \
       || return 1
     
-    if is_raspbian ; then
-        DEPENDENCIES="ssl-cert lua-event lua-expat lua-socket lua-sec lua-filesystem"
-        apt_get_wrapper -o Dpkg::Options::="--force-confold" \
-                        -y --force-yes install               \
-                        $DEPENDENCIES                        \
-        || return 1
-        wget -q https://build.yunohost.org/metronome_3.7.9+33b7572-1_armhf.deb \
-        || return 1
-        sha256sum -c <<<"d19c6b08afb8674d1257dc3349a60e88218c4c01133c53c1fdcb02e86b415a40  metronome_3.7.9+33b7572-1_armhf.deb" \
-        || return 1
-        dpkg -i metronome_3.7.9+33b7572-1_armhf.deb >> $YUNOHOST_LOG 2>&1 \
-        || return 1
-        apt-mark hold metronome >> $YUNOHOST_LOG 2>&1 \
-        || return 1
-    fi
 
 }
 

--- a/install_yunohost
+++ b/install_yunohost
@@ -155,7 +155,7 @@ Your configuration files for :
   - dovecot
   - mysql
   - nginx
-  - metronome
+  - prosody
 will be overwritten !
 
 Are you sure you want  to proceed with the installation of Yunohost?
@@ -188,6 +188,10 @@ setup_package_source() {
 
     # Add YunoHost repository key to the keyring
     wget -O- https://repo.yunohost.org/yunohost.asc -q | apt-key add -qq - > /dev/null
+
+    # Add Prosody repository source and key
+    echo "deb http://packages.prosody.im/debian jessie main" > "/etc/apt/sources.list.d/prosody.list"
+    wget -O- https://prosody.im/files/prosody-debian-packages.key | apt-key add -qq - > /dev/null
 }
 
 apt_update() {


### PR DESCRIPTION
Not tested, just to push something:
- remove metronome install for RPi
- add Prosody repository and key

**To be merged at the same time as https://github.com/YunoHost/yunohost/pull/240**