### PR TITLE
Clean / improve install script

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -82,7 +82,7 @@ function main()
     check_assertions
 
     step upgrade_system                || die "Unable to update the system"
-    step installscript_dependencies    || die "Unable to install dependencies to install script"
+    step install_script_dependencies   || die "Unable to install dependencies to install script"
     step create_custom_config          || die "Creating custom configuration file /etc/yunohost/yunohost.conf failed"
     step confirm_installation          || die "Installation cancelled at your request"
     step setup_package_source          || die "Setting up deb package sources failed"
@@ -248,7 +248,7 @@ function upgrade_system() {
     fi
 }
 
-function installscript_dependencies() {
+function install_script_dependencies() {
     # dependencies of the install script itself
     local DEPENDENCIES="lsb-release wget whiptail"
 

--- a/install_yunohost
+++ b/install_yunohost
@@ -425,71 +425,82 @@ Options :
 # to the standard error, and a non-interactive shell will exit.
 set -u
 
-AUTOMODE=0
-DISTRIB=stable
-BUILD_IMAGE=0
-while getopts ":aid:h" option; do
-  case $option in
-    a)
-      AUTOMODE=1
-      export DEBIAN_FRONTEND=noninteractive
-      ;;
-    d)
-      DISTRIB=$OPTARG
-      ;;
-    i)
-      # This hidden option will allow to build generic image for Rpi/Olimex
-      BUILD_IMAGE=1
-      ;;
-    h)
-      usage
-      exit 0
-      ;;
-    :)
-      usage
-      exit 1
-      ;;
-    \?)
-      usage
-      exit 1
-      ;;
-  esac
-done
+function parse_options()
+{
+    AUTOMODE=0
+    DISTRIB=stable
+    BUILD_IMAGE=0
 
-step ensure_root || die "This script must be run as root"
+    while getopts ":aid:h" option; do
+        case $option in
+            a)
+                AUTOMODE=1
+                export DEBIAN_FRONTEND=noninteractive
+                ;;
+            d)
+                DISTRIB=$OPTARG
+                ;;
+            i)
+                # This hidden option will allow to build generic image for Rpi/Olimex
+                BUILD_IMAGE=1
+                ;;
+            h)
+                usage
+                exit 0
+                ;;
+            :)
+                usage
+                exit 1
+                ;;
+            \?)
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
 
-if is_raspbian ; then
-    step ensure_pi_logout || die "The user pi should be logged out"
-fi
+function main()
+{
+    parse_options
 
-step upgrade_system                || die "Unable to update the system"
-step installscript_dependencies    || die "Unable to install dependencies to install script"
-step create_custom_config          || die "Creating custom configuration file /etc/yunohost/yunohost.conf failed"
-step confirm_installation          || die "Installation cancelled at your request"
-step setup_package_source          || die "Setting up deb package sources failed"
-step apt_update                    || die "Error caught during 'apt-get update'"
-step register_debconf              || die "Unable to insert new values into debconf database"
-step workaround_avahi_installation || die "Unable to install workaround for avahi installation"
-step install_yunohost_packages     || die "Installation of Yunohost packages failed"
-step restart_services              || die "Error caught during services restart"
+    step ensure_root || die "This script must be run as root"
 
-if is_raspbian ; then
-    step del_user_pi     || die "Unable to delete user pi"
-    step change_hostname || die "Unable to change hostname"
-    step setup_firstboot || die "Unable to setup firstboot"
-fi
+    if is_raspbian ; then
+        step ensure_pi_logout || die "The user pi should be logged out"
+    fi
 
-if [[ "$BUILD_IMAGE" == "1" ]] ; then
-    step clean_image || die "Unable to clean image"
-fi
+    step upgrade_system                || die "Unable to update the system"
+    step installscript_dependencies    || die "Unable to install dependencies to install script"
+    step create_custom_config          || die "Creating custom configuration file /etc/yunohost/yunohost.conf failed"
+    step confirm_installation          || die "Installation cancelled at your request"
+    step setup_package_source          || die "Setting up deb package sources failed"
+    step apt_update                    || die "Error caught during 'apt-get update'"
+    step register_debconf              || die "Unable to insert new values into debconf database"
+    step workaround_avahi_installation || die "Unable to install workaround for avahi installation"
+    step install_yunohost_packages     || die "Installation of Yunohost packages failed"
+    step restart_services              || die "Error caught during services restart"
 
-if is_raspbian ; then
-    # Reboot should be done before postinstall to be able to run iptables rules
-    reboot
-fi
+    if is_raspbian ; then
+        step del_user_pi     || die "Unable to delete user pi"
+        step change_hostname || die "Unable to change hostname"
+        step setup_firstboot || die "Unable to setup firstboot"
+    fi
 
-step post_install || die "Post-installation failed"
+    if [[ "$BUILD_IMAGE" == "1" ]] ; then
+        step clean_image || die "Unable to clean image"
+    fi
 
-# Success !
-success
-exit 0
+    if is_raspbian ; then
+        # Reboot should be done before postinstall to be able to run iptables rules
+        reboot
+    fi
+
+    step post_install || die "Post-installation failed"
+
+    # Success !
+    success
+    exit 0
+}
+
+main

--- a/install_yunohost
+++ b/install_yunohost
@@ -20,7 +20,6 @@ set -u
 # Globals
 
 readonly YUNOHOST_LOG="/var/log/yunohost-installation.log"
-readonly THIS_MACHINE_RELEASE="$(lsb_release -c | awk '{print $2}')"
 
 ###############################################################################
 # Main functions                                                              #
@@ -49,7 +48,7 @@ function parse_options()
     BUILD_IMAGE=0
     FORCE=0
 
-    while getopts ":aid:h" option; do
+    while getopts ":aid:fh" option; do
         case $option in
             a)
                 AUTOMODE=1
@@ -83,7 +82,9 @@ function parse_options()
 
 function main()
 {
-    parse_options
+    parse_options "$@"
+
+    rm -f $YUNOHOST_LOG
 
     check_assertions
 
@@ -203,10 +204,10 @@ function check_assertions()
     # Assert we're on Stretch
     # Note : we do not rely on lsb_release to avoid installing a dependency
     # only to check this...
-    [[ ! "$(cat /etc/debian_version)" =~ ^9.* ]] || die "This script can only be ran on Debian Stretch."
+    [[ "$(cat /etc/debian_version)" =~ ^9.* ]] || die "This script can only be ran on Debian Stretch."
 
     # Assert we're root
-    [[ "$(id -u)" != "0" ]] || die "This script must be run as root."
+    [[ "$(id -u)" == "0" ]] || die "This script must be run as root."
 
     # Assert systemd is installed
     command -v systemctl > /dev/null || die "YunoHost requires systemd to be installed."
@@ -218,10 +219,10 @@ function check_assertions()
     fi
 
     # Check possible conflict with apache, bind9.
-    [[ -z "$(dpkg --list | grep ' bind9')" ]] || [[ "$FORCE" == "1" ]] \
+    [[ -z "$(dpkg --get-selections | grep -v deinstall | grep 'bind9 ')" ]] || [[ "$FORCE" == "1" ]] \
         || die "Bind9 is installed and might conflict with dnsmasq. Uninstall it first, or if you know what you are doing, run this script with -f."
 
-    [[ -z "$(dpkg --list | grep ' apache2')" ]] || [[ "$FORCE" == "1" ]] \
+    [[ -z "$(dpkg --get-selections | grep -v deinstall | grep 'apache2 ')" ]] || [[ "$FORCE" == "1" ]] \
         || die "Apache is installed and might conflict with nginx. Uninstall it first, or if you know what you are doing, run this script with -f."
 
 }
@@ -517,4 +518,4 @@ function clean_image() {
 
 ###############################################################################
 
-main
+main "$@"

--- a/install_yunohost
+++ b/install_yunohost
@@ -18,25 +18,25 @@
 YUNOHOST_LOG="/var/log/yunohost-installation.log"
 THIS_MACHINE_RELEASE="$(lsb_release -c | awk '{print $2}')"
 
-print() {
+function print() {
     printf "%s\n" "$*";
 }
 
-notify_about_install_logs() {
+function notify_about_install_logs() {
     print "
 Installation logs are located in $YUNOHOST_LOG
 " 1>&2
 
 }
 
-success() {
+function success() {
     tput setf 2
     print "Success !"
     tput sgr 0
     notify_about_install_logs
 }
 
-die() {
+function die() {
     # Print to log file
     print "
 Failure !
@@ -60,14 +60,14 @@ $1
     exit "${2:-1}"
 }
 
-step() {
+function step() {
   printf "[ $(date --rfc-3339=seconds) ] ----- [ entering %-30s ]\n" "$1" >> $YUNOHOST_LOG
   $*
   local return_code="$?"
   return $return_code
 }
 
-ensure_root() {
+function ensure_root() {
     if [[ "$(id -u)" != "0" ]] ;
     then
         return 1
@@ -75,12 +75,12 @@ ensure_root() {
     return 0
 }
 
-ensure_pi_logout() {
+function ensure_pi_logout() {
     who | grep pi > /dev/null && return 1
     return 0
 }
 
-is_raspbian() {
+function is_raspbian() {
     # On Raspbian image lsb_release is available
     if [[ "$(lsb_release -i -s 2> /dev/null)" != "Raspbian" ]] ;
     then
@@ -89,7 +89,7 @@ is_raspbian() {
     return 0
 }
 
-apt_get_wrapper() {
+function apt_get_wrapper() {
     if [[ "$AUTOMODE" == "0" ]] ;
     then
       debconf-apt-progress                             \
@@ -101,7 +101,7 @@ apt_get_wrapper() {
     fi
 }
 
-upgrade_system() {
+function upgrade_system() {
 
     apt_get_wrapper update \
     || return 1
@@ -120,7 +120,7 @@ upgrade_system() {
     fi
 }
 
-installscript_dependencies() {
+function installscript_dependencies() {
     # dependencies of the install script itself
     local DEPENDENCIES="lsb-release wget whiptail"
 
@@ -156,7 +156,7 @@ installscript_dependencies() {
 
 }
 
-create_custom_config() {
+function create_custom_config() {
     # Create YunoHost configuration folder
     mkdir -p /etc/yunohost/
 
@@ -164,7 +164,7 @@ create_custom_config() {
     touch /etc/yunohost/from_script
 }
 
-confirm_installation() {
+function confirm_installation() {
   [[ "$AUTOMODE" == "1" ]] && return 0
 
   local text="
@@ -183,7 +183,7 @@ Are you sure you want  to proceed with the installation of Yunohost?
   whiptail --title "Yunohost Installation" --yesno "$text" 20 78
 }
 
-setup_package_source() {
+function setup_package_source() {
     local CUSTOMAPT=/etc/apt/sources.list.d/yunohost.list
 
     # Check current system version and dependencies
@@ -214,11 +214,11 @@ setup_package_source() {
     wget -O- https://vinaigrette.yunohost.org/yunohost.asc -q | apt-key add -qq - >/dev/null 2>&1
 }
 
-apt_update() {
+function apt_update() {
     apt_get_wrapper update
 }
 
-register_debconf() {
+function register_debconf() {
     debconf-set-selections << EOF 
 slapd slapd/password1 password yunohost
 slapd slapd/password2 password yunohost
@@ -243,7 +243,7 @@ libnss-ldapd    libnss-ldapd/nsswitch multiselect group, passwd, shadow
 EOF
 }
 
-workaround_avahi_installation() {
+function workaround_avahi_installation() {
 
     # When attempting several installation of Yunohost on the same host
     # with a light VM system like LXC
@@ -283,7 +283,7 @@ workaround_avahi_installation() {
         --uid $avahi_id
 }
 
-install_yunohost_packages() {
+function install_yunohost_packages() {
     # Allow sudo removal even if no root password has been set (on some DO
     # droplet or Vagrant virtual machines), as YunoHost use sudo-ldap
     export SUDO_FORCE_REMOVE=yes
@@ -299,7 +299,7 @@ install_yunohost_packages() {
         yunohost yunohost-admin postfix
 }
 
-restart_services() {
+function restart_services() {
     service slapd restart
 #    service yunohost-firewall start
     service unscd restart
@@ -309,16 +309,16 @@ restart_services() {
     return 0
 }
 
-del_user_pi() {
+function del_user_pi() {
     deluser --remove-all-files pi >> $YUNOHOST_LOG 2>&1
 }
 
-change_hostname() {
+function change_hostname() {
     sed -i 's/raspberrypi/yunohost/g' /etc/hosts
     sed -i 's/raspberrypi/yunohost/g' /etc/hostname
 }
 
-setup_firstboot() {
+function setup_firstboot() {
 
     cat > /etc/init.d/yunohost-firstboot << EOF
 #!/bin/sh
@@ -345,7 +345,7 @@ EOF
     touch /etc/yunohost/firstboot
 }
 
-clean_image() {
+function clean_image() {
     # Delete SSH keys
     rm -f /etc/ssh/ssh_host_* >> $YUNOHOST_LOG 2>&1
     yes | ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa >> $YUNOHOST_LOG 2>&1
@@ -359,7 +359,7 @@ clean_image() {
     apt-get --purge clean >> $YUNOHOST_LOG 2>&1
 }
 
-post_install() {
+function post_install() {
     # No postinstall in auto mode
     [[ "$AUTOMODE" == "1" ]] && return 0
 
@@ -406,7 +406,7 @@ Do you want to try again now?
     return 0
 }
 
-usage() {
+function usage() {
   print "
 Usage :
   `basename $0` [-a] [-d <DISTRIB>] [-h]

--- a/install_yunohost
+++ b/install_yunohost
@@ -15,8 +15,112 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-YUNOHOST_LOG="/var/log/yunohost-installation.log"
-THIS_MACHINE_RELEASE="$(lsb_release -c | awk '{print $2}')"
+set -u
+
+# Globals
+
+readonly YUNOHOST_LOG="/var/log/yunohost-installation.log"
+readonly THIS_MACHINE_RELEASE="$(lsb_release -c | awk '{print $2}')"
+
+###############################################################################
+# Main functions                                                              #
+###############################################################################
+
+function usage() {
+  print "
+Usage :
+  `basename $0` [-a] [-d <DISTRIB>] [-h]
+
+Options :
+  -a      Enable automatic mode. No questions are asked.
+          This does not perform the post-install step.
+  -d      Choose the distribution to install ('stable', 'testing', 'unstable').
+          Defaults to 'stable'
+  -h      Prints this help and exit
+"
+}
+
+function parse_options()
+{
+    AUTOMODE=0
+    DISTRIB=stable
+    BUILD_IMAGE=0
+
+    while getopts ":aid:h" option; do
+        case $option in
+            a)
+                AUTOMODE=1
+                export DEBIAN_FRONTEND=noninteractive
+                ;;
+            d)
+                DISTRIB=$OPTARG
+                ;;
+            i)
+                # This hidden option will allow to build generic image for Rpi/Olimex
+                BUILD_IMAGE=1
+                ;;
+            h)
+                usage
+                exit 0
+                ;;
+            :)
+                usage
+                exit 1
+                ;;
+            \?)
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+function main()
+{
+    parse_options
+
+    step ensure_root || die "This script must be run as root"
+
+    if is_raspbian ; then
+        step ensure_pi_logout || die "The user pi should be logged out"
+    fi
+
+    step upgrade_system                || die "Unable to update the system"
+    step installscript_dependencies    || die "Unable to install dependencies to install script"
+    step create_custom_config          || die "Creating custom configuration file /etc/yunohost/yunohost.conf failed"
+    step confirm_installation          || die "Installation cancelled at your request"
+    step setup_package_source          || die "Setting up deb package sources failed"
+    step apt_update                    || die "Error caught during 'apt-get update'"
+    step register_debconf              || die "Unable to insert new values into debconf database"
+    step workaround_avahi_installation || die "Unable to install workaround for avahi installation"
+    step install_yunohost_packages     || die "Installation of Yunohost packages failed"
+    step restart_services              || die "Error caught during services restart"
+
+    if is_raspbian ; then
+        step del_user_pi     || die "Unable to delete user pi"
+        step change_hostname || die "Unable to change hostname"
+        step setup_firstboot || die "Unable to setup firstboot"
+    fi
+
+    if [[ "$BUILD_IMAGE" == "1" ]] ; then
+        step clean_image || die "Unable to clean image"
+    fi
+
+    if is_raspbian ; then
+        # Reboot should be done before postinstall to be able to run iptables rules
+        reboot
+    fi
+
+    step post_install || die "Post-installation failed"
+
+    # Success !
+    success
+    exit 0
+}
+
+###############################################################################
+# Helpers                                                                     #
+###############################################################################
 
 function print() {
     printf "%s\n" "$*";
@@ -88,6 +192,10 @@ function is_raspbian() {
     fi
     return 0
 }
+
+###############################################################################
+# Installation steps                                                          #
+###############################################################################
 
 function apt_get_wrapper() {
     if [[ "$AUTOMODE" == "0" ]] ;
@@ -404,103 +512,6 @@ Do you want to try again now?
         POSTINSTALL_EXIT_CODE="$?"
     done
     return 0
-}
-
-function usage() {
-  print "
-Usage :
-  `basename $0` [-a] [-d <DISTRIB>] [-h]
-
-Options :
-  -a      Enable automatic mode. No questions are asked.
-          This does not perform the post-install step.
-  -d      Choose the distribution to install ('stable', 'testing', 'unstable').
-          Defaults to 'stable'
-  -h      Prints this help and exit
-"
-}
-
-# Treat unset variables as an error when performing
-# parameter expansion. An error message will be written
-# to the standard error, and a non-interactive shell will exit.
-set -u
-
-function parse_options()
-{
-    AUTOMODE=0
-    DISTRIB=stable
-    BUILD_IMAGE=0
-
-    while getopts ":aid:h" option; do
-        case $option in
-            a)
-                AUTOMODE=1
-                export DEBIAN_FRONTEND=noninteractive
-                ;;
-            d)
-                DISTRIB=$OPTARG
-                ;;
-            i)
-                # This hidden option will allow to build generic image for Rpi/Olimex
-                BUILD_IMAGE=1
-                ;;
-            h)
-                usage
-                exit 0
-                ;;
-            :)
-                usage
-                exit 1
-                ;;
-            \?)
-                usage
-                exit 1
-                ;;
-        esac
-    done
-}
-
-function main()
-{
-    parse_options
-
-    step ensure_root || die "This script must be run as root"
-
-    if is_raspbian ; then
-        step ensure_pi_logout || die "The user pi should be logged out"
-    fi
-
-    step upgrade_system                || die "Unable to update the system"
-    step installscript_dependencies    || die "Unable to install dependencies to install script"
-    step create_custom_config          || die "Creating custom configuration file /etc/yunohost/yunohost.conf failed"
-    step confirm_installation          || die "Installation cancelled at your request"
-    step setup_package_source          || die "Setting up deb package sources failed"
-    step apt_update                    || die "Error caught during 'apt-get update'"
-    step register_debconf              || die "Unable to insert new values into debconf database"
-    step workaround_avahi_installation || die "Unable to install workaround for avahi installation"
-    step install_yunohost_packages     || die "Installation of Yunohost packages failed"
-    step restart_services              || die "Error caught during services restart"
-
-    if is_raspbian ; then
-        step del_user_pi     || die "Unable to delete user pi"
-        step change_hostname || die "Unable to change hostname"
-        step setup_firstboot || die "Unable to setup firstboot"
-    fi
-
-    if [[ "$BUILD_IMAGE" == "1" ]] ; then
-        step clean_image || die "Unable to clean image"
-    fi
-
-    if is_raspbian ; then
-        # Reboot should be done before postinstall to be able to run iptables rules
-        reboot
-    fi
-
-    step post_install || die "Post-installation failed"
-
-    # Success !
-    success
-    exit 0
 }
 
 main

--- a/install_yunohost
+++ b/install_yunohost
@@ -36,6 +36,8 @@ Options :
           This does not perform the post-install step.
   -d      Choose the distribution to install ('stable', 'testing', 'unstable').
           Defaults to 'stable'
+  -f      Ignore checks before starting the installation. Use only if you know
+          what you are doing.
   -h      Prints this help and exit
 "
 }
@@ -45,6 +47,7 @@ function parse_options()
     AUTOMODE=0
     DISTRIB=stable
     BUILD_IMAGE=0
+    FORCE=0
 
     while getopts ":aid:h" option; do
         case $option in
@@ -54,6 +57,9 @@ function parse_options()
                 ;;
             d)
                 DISTRIB=$OPTARG
+                ;;
+            f)
+                FORCE=1
                 ;;
             i)
                 # This hidden option will allow to build generic image for Rpi/Olimex
@@ -210,6 +216,14 @@ function check_assertions()
     if is_raspbian ; then
         user_pi_logged_out || die "The user pi should be logged out."
     fi
+
+    # Check possible conflict with apache, bind9.
+    [[ -z "$(dpkg --list | grep ' bind9')" ]] || [[ "$FORCE" == "1" ]] \
+        || die "Bind9 is installed and might conflict with dnsmasq. Uninstall it first, or if you know what you are doing, run this script with -f."
+
+    [[ -z "$(dpkg --list | grep ' apache2')" ]] || [[ "$FORCE" == "1" ]] \
+        || die "Apache is installed and might conflict with nginx. Uninstall it first, or if you know what you are doing, run this script with -f."
+
 }
 
 function upgrade_system() {

--- a/install_yunohost
+++ b/install_yunohost
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2015 kload, beudbeud
+# Copyright (C) 2015-2017 YunoHost
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/install_yunohost
+++ b/install_yunohost
@@ -79,11 +79,7 @@ function main()
 {
     parse_options
 
-    step ensure_root || die "This script must be run as root"
-
-    if is_raspbian ; then
-        step ensure_pi_logout || die "The user pi should be logged out"
-    fi
+    check_assertions
 
     step upgrade_system                || die "Unable to update the system"
     step installscript_dependencies    || die "Unable to install dependencies to install script"
@@ -178,7 +174,7 @@ function ensure_root() {
     return 0
 }
 
-function ensure_pi_logout() {
+function user_pi_logged_out() {
     who | grep pi > /dev/null && return 1
     return 0
 }
@@ -195,6 +191,31 @@ function is_raspbian() {
 ###############################################################################
 # Installation steps                                                          #
 ###############################################################################
+
+function check_assertions()
+{
+    # Assert we're on Debian
+    # Note : we do not rely on lsb_release to avoid installing a dependency
+    # only to check this...
+    [[ -f "/etc/debian_version" ]] || die "This script can only be ran on Debian."
+
+    # Assert we're on Stretch
+    # Note : we do not rely on lsb_release to avoid installing a dependency
+    # only to check this...
+    [[ ! "$(cat /etc/debian_version)" =~ ^9.* ]] || die "This script can only be ran on Debian Stretch."
+
+    # Assert we're root
+    [[ "$(id -u)" != "0" ]] || die "This script must be run as root."
+
+    # Assert systemd is installed
+    command -v systemctl > /dev/null || die "YunoHost requires systemd to be installed."
+
+    # If we're on Raspbian, we want the user 'pi' to be logged out because
+    # it's going to be deleted for security reasons...
+    if is_raspbian ; then
+        user_pi_logged_out || die "The user pi should be logged out."
+    fi
+}
 
 function apt_get_wrapper() {
     if [[ "$AUTOMODE" == "0" ]] ;
@@ -215,12 +236,12 @@ function upgrade_system() {
 
     apt_get_wrapper -y dist-upgrade \
     || return 2
-    
+
     if is_raspbian ; then
         apt_get_wrapper -o Dpkg::Options::="--force-confold" \
                         -y --force-yes install rpi-update \
         || return 3
-        
+
         rpi-update >> $YUNOHOST_LOG 2>&1 \
         || return 4
 
@@ -270,17 +291,8 @@ Are you sure you want  to proceed with the installation of Yunohost?
 }
 
 function setup_package_source() {
+
     local CUSTOMAPT=/etc/apt/sources.list.d/yunohost.list
-
-    # Check current system version and dependencies
-
-    if [[ ! $THIS_MACHINE_RELEASE =~ ^jessie|stretch$ ]]; then
-        echo "Current $DISTRIB only works on Debian Jessie or Stretch for the moment."
-        return 1
-    elif ! command -v systemctl > /dev/null ; then
-        echo "Current $DISTRIB only works with systemd for the moment."
-        return 1
-    fi
 
     # Debian repository
 
@@ -305,7 +317,7 @@ function apt_update() {
 }
 
 function register_debconf() {
-    debconf-set-selections << EOF 
+    debconf-set-selections << EOF
 slapd slapd/password1 password yunohost
 slapd slapd/password2 password yunohost
 slapd slapd/domain    string yunohost.org
@@ -373,7 +385,7 @@ function install_yunohost_packages() {
     # Allow sudo removal even if no root password has been set (on some DO
     # droplet or Vagrant virtual machines), as YunoHost use sudo-ldap
     export SUDO_FORCE_REMOVE=yes
-    
+
     # On some machines (e.g. OVH VPS), the /etc/resolv.conf is immutable
     # We need to make it mutable for the resolvconf dependency to be installed
     chattr -i /etc/resolv.conf 2>/dev/null || true
@@ -432,10 +444,10 @@ function clean_image() {
     yes | ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa >> $YUNOHOST_LOG 2>&1
     yes | ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa >> $YUNOHOST_LOG 2>&1
     yes | ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa -b 521 >> $YUNOHOST_LOG 2>&1
-    
+
     # Deleting logs ...
     find /var/log -type f -exec rm {} \; >> $YUNOHOST_LOG 2>&1
-    
+
     # Purging apt ...
     apt-get --purge clean >> $YUNOHOST_LOG 2>&1
 }

--- a/install_yunohost
+++ b/install_yunohost
@@ -241,27 +241,6 @@ function installscript_dependencies() {
                     -y --force-yes install               \
                     $DEPENDENCIES                        \
       || return 1
-    
-    #
-    # Temporary comment for stretch... 
-    # To be removed if really not needed
-    #
-    #if is_raspbian ; then
-    #    DEPENDENCIES="ssl-cert lua-event lua-expat lua-socket lua-sec lua-filesystem"
-    #    apt_get_wrapper -o Dpkg::Options::="--force-confold" \
-    #                    -y --force-yes install               \
-    #                    $DEPENDENCIES                        \
-    #    || return 1
-    #    wget -q https://build.yunohost.org/metronome_3.7.9+33b7572-1_armhf.deb \
-    #    || return 1
-    #    sha256sum -c <<<"d19c6b08afb8674d1257dc3349a60e88218c4c01133c53c1fdcb02e86b415a40  metronome_3.7.9+33b7572-1_armhf.deb" \
-    #    || return 1
-    #    dpkg -i metronome_3.7.9+33b7572-1_armhf.deb >> $YUNOHOST_LOG 2>&1 \
-    #    || return 1
-    #    apt-mark hold metronome >> $YUNOHOST_LOG 2>&1 \
-    #    || return 1
-    #fi
-
 }
 
 function create_custom_config() {

--- a/install_yunohost
+++ b/install_yunohost
@@ -138,25 +138,25 @@ readonly white=$(printf '\033[39m')
 function success()
 {
   local msg=${1}
-  echo "[${green} OK ${normal}] ${msg}" | tee -a $YUNOHOST_LOG
+  echo "[${bold}${green} OK ${normal}] ${msg}" | tee -a $YUNOHOST_LOG
 }
 
 function info()
 {
   local msg=${1}
-  echo "[${blue}INFO${normal}] ${msg}" | tee -a $YUNOHOST_LOG
+  echo "[${bold}${blue}INFO${normal}] ${msg}" | tee -a $YUNOHOST_LOG
 }
 
 function warn()
 {
   local msg=${1}
-  echo "[${orange}WARN${normal}] ${msg}" | tee -a $YUNOHOST_LOG >&2
+  echo "[${bold}${orange}WARN${normal}] ${msg}" | tee -a $YUNOHOST_LOG >&2
 }
 
 function error()
 {
   local msg=${1}
-  echo "[${red}FAIL${normal}] ${msg}" | tee -a $YUNOHOST_LOG >&2
+  echo "[${bold}${red}FAIL${normal}] ${msg}" | tee -a $YUNOHOST_LOG >&2
 }
 
 function die() {

--- a/install_yunohost
+++ b/install_yunohost
@@ -19,7 +19,7 @@ set -u
 
 # Globals
 
-readonly YUNOHOST_LOG="/var/log/yunohost-installation.log"
+readonly YUNOHOST_LOG="/var/log/yunohost-installation_$(date +%Y%m%d_%H%M%S).log"
 
 ###############################################################################
 # Main functions                                                              #
@@ -83,8 +83,6 @@ function parse_options()
 function main()
 {
     parse_options "$@"
-
-    rm -f $YUNOHOST_LOG
 
     check_assertions
 

--- a/install_yunohost
+++ b/install_yunohost
@@ -27,7 +27,7 @@ readonly THIS_MACHINE_RELEASE="$(lsb_release -c | awk '{print $2}')"
 ###############################################################################
 
 function usage() {
-  print "
+  echo "
 Usage :
   `basename $0` [-a] [-d <DISTRIB>] [-h]
 
@@ -108,8 +108,8 @@ function main()
 
     step post_install || die "Post-installation failed"
 
-    # Success !
-    success
+    info "Installation logs are available in $YUNOHOST_LOG"
+    success "YunoHost installation completed !"
     exit 0
 }
 
@@ -117,50 +117,50 @@ function main()
 # Helpers                                                                     #
 ###############################################################################
 
-function print() {
-    printf "%s\n" "$*";
+readonly normal=$(printf '\033[0m')
+readonly bold=$(printf '\033[1m')
+readonly faint=$(printf '\033[2m')
+readonly underline=$(printf '\033[4m')
+readonly negative=$(printf '\033[7m')
+readonly red=$(printf '\033[31m')
+readonly green=$(printf '\033[32m')
+readonly orange=$(printf '\033[33m')
+readonly blue=$(printf '\033[34m')
+readonly yellow=$(printf '\033[93m')
+readonly white=$(printf '\033[39m')
+
+function success()
+{
+  local msg=${1}
+  echo "[${green} OK ${normal}] ${msg}" | tee -a $YUNOHOST_LOG
 }
 
-function notify_about_install_logs() {
-    print "
-Installation logs are located in $YUNOHOST_LOG
-" 1>&2
-
+function info()
+{
+  local msg=${1}
+  echo "[${blue}INFO${normal}] ${msg}" | tee -a $YUNOHOST_LOG
 }
 
-function success() {
-    tput setf 2
-    print "Success !"
-    tput sgr 0
-    notify_about_install_logs
+function warn()
+{
+  local msg=${1}
+  echo "[${orange}WARN${normal}] ${msg}" | tee -a $YUNOHOST_LOG >&2
+}
+
+function error()
+{
+  local msg=${1}
+  echo "[${red}FAIL${normal}] ${msg}" | tee -a $YUNOHOST_LOG >&2
 }
 
 function die() {
-    # Print to log file
-    print "
-Failure !
-The following error was caught during Yunohost installation :
-
-$1
-" >> $YUNOHOST_LOG
-
-    # Print to terminal
-    tput setf 4
-    print "Failure !"
-    tput sgr 0
-
-    print "\
-The following error was caught during YunoHost installation :
-
-$1
-" 1>&2
-
-    notify_about_install_logs
-    exit "${2:-1}"
+    error "$1"
+    info "Installation logs are available in $YUNOHOST_LOG"
+    exit 1
 }
 
 function step() {
-  printf "[ $(date --rfc-3339=seconds) ] ----- [ entering %-30s ]\n" "$1" >> $YUNOHOST_LOG
+  info "Running $1"
   $*
   local return_code="$?"
   return $return_code
@@ -339,7 +339,7 @@ function workaround_avahi_installation() {
 
     # Return without error if avahi already exists
     if id avahi > /dev/null 2>&1 ; then
-        print "User avahi already exists (with uid $(id avahi)), skipping avahi workaround" >> $YUNOHOST_LOG
+        info "User avahi already exists (with uid $(id avahi)), skipping avahi workaround"
         return 0
     fi
 
@@ -350,7 +350,7 @@ function workaround_avahi_installation() {
         avahi_id=$((500 + RANDOM % 500))
     done
 
-    print "Workaround for avahi : creating avahi user with uid $avahi_id" >> $YUNOHOST_LOG
+    info "Workaround for avahi : creating avahi user with uid $avahi_id"
 
     # Use the same adduser parameter as in the avahi-daemon postinst script
     # Just specify --uid explicitely

--- a/install_yunohost
+++ b/install_yunohost
@@ -456,78 +456,31 @@ while getopts ":aid:h" option; do
   esac
 done
 
-if ! step ensure_root ; then
-  die "This script must be run as root" 1
-fi
+step ensure_root || die "This script must be run as root"
 
 if is_raspbian ; then
-    if ! step ensure_pi_logout ; then
-      die "The user pi should be logged out" 14
-    fi
+    step ensure_pi_logout || die "The user pi should be logged out"
 fi
 
-if ! step upgrade_system ; then
-  die "Unable to update the system" 2
-fi
-
-if ! step installscript_dependencies ; then
-  die "Unable to install dependencies to install script" 3
-fi
-
-if ! step create_custom_config ; then
-  die "Creating custom configuration file /etc/yunohost/yunohost.conf failed" 4
-fi
-
-# if ! step set_domain ; then
-#   die "Setting hostname failed" 5
-# fi
-
-if ! step confirm_installation ; then
-  die "Installation cancelled at your request" 6
-fi
-
-if ! step setup_package_source ; then
-  die "Setting up deb package sources failed" 7
-fi
-
-if ! step apt_update ; then
-  die "Error caught during 'apt-get update'" 8
-fi
-
-if ! step register_debconf ; then
-  die "Unable to insert new values into debconf database" 9
-fi
-
-if ! step workaround_avahi_installation ; then
-  die "Unable to install workaround for avahi installation" 10
-fi
-
-if ! step install_yunohost_packages ; then
-  die "Installation of Yunohost packages failed" 11
-fi
-
-if ! step restart_services ; then
-  die "Error caught during services restart" 12
-fi
+step upgrade_system                || die "Unable to update the system"
+step installscript_dependencies    || die "Unable to install dependencies to install script"
+step create_custom_config          || die "Creating custom configuration file /etc/yunohost/yunohost.conf failed"
+step confirm_installation          || die "Installation cancelled at your request"
+step setup_package_source          || die "Setting up deb package sources failed"
+step apt_update                    || die "Error caught during 'apt-get update'"
+step register_debconf              || die "Unable to insert new values into debconf database"
+step workaround_avahi_installation || die "Unable to install workaround for avahi installation"
+step install_yunohost_packages     || die "Installation of Yunohost packages failed"
+step restart_services              || die "Error caught during services restart"
 
 if is_raspbian ; then
-    if ! step del_user_pi ; then
-        die "Unable to delete user pi" 15
-    fi
-
-    if ! step change_hostname ; then
-        die "Unable to change hostname" 16
-    fi
-    
-    if ! step setup_firstboot ; then
-        die "Unable to setup firstboot" 17
-    fi
+    step del_user_pi     || die "Unable to delete user pi"
+    step change_hostname || die "Unable to change hostname"
+    step setup_firstboot || die "Unable to setup firstboot"
 fi
 
 if [[ "$BUILD_IMAGE" == "1" ]] ; then
-    if ! step clean_image ; then
-        die "Unable to clean image" 18
-    fi
+    step clean_image || die "Unable to clean image"
 fi
 
 if is_raspbian ; then
@@ -535,10 +488,7 @@ if is_raspbian ; then
     reboot
 fi
 
-if ! step post_install ; then
-  die "Post-installation failed" 13 
-fi
-
+step post_install || die "Post-installation failed"
 
 # Success !
 success

--- a/install_yunohost
+++ b/install_yunohost
@@ -166,26 +166,21 @@ function step() {
   return $return_code
 }
 
-function ensure_root() {
-    if [[ "$(id -u)" != "0" ]] ;
+function apt_get_wrapper() {
+    if [[ "$AUTOMODE" == "0" ]] ;
     then
-        return 1
+      debconf-apt-progress                             \
+          --logfile $YUNOHOST_LOG                      \
+          --                                           \
+          apt-get $*
+    else
+        apt-get $* >> $YUNOHOST_LOG 2>&1
     fi
-    return 0
 }
 
-function user_pi_logged_out() {
-    who | grep pi > /dev/null && return 1
-    return 0
-}
 
-function is_raspbian() {
-    # On Raspbian image lsb_release is available
-    if [[ "$(lsb_release -i -s 2> /dev/null)" != "Raspbian" ]] ;
-    then
-        return 1
-    fi
-    return 0
+function apt_update() {
+    apt_get_wrapper update
 }
 
 ###############################################################################
@@ -214,18 +209,6 @@ function check_assertions()
     # it's going to be deleted for security reasons...
     if is_raspbian ; then
         user_pi_logged_out || die "The user pi should be logged out."
-    fi
-}
-
-function apt_get_wrapper() {
-    if [[ "$AUTOMODE" == "0" ]] ;
-    then
-      debconf-apt-progress                             \
-          --logfile $YUNOHOST_LOG                      \
-          --                                           \
-          apt-get $*
-    else
-        apt-get $* >> $YUNOHOST_LOG 2>&1
     fi
 }
 
@@ -310,10 +293,6 @@ function setup_package_source() {
     # Add YunoHost repository key to the keyring
     # FIXME : move "vinaigrette." to "repo." at some point...
     wget -O- https://vinaigrette.yunohost.org/yunohost.asc -q | apt-key add -qq - >/dev/null 2>&1
-}
-
-function apt_update() {
-    apt_get_wrapper update
 }
 
 function register_debconf() {
@@ -407,51 +386,6 @@ function restart_services() {
     return 0
 }
 
-function del_user_pi() {
-    deluser --remove-all-files pi >> $YUNOHOST_LOG 2>&1
-}
-
-function setup_firstboot() {
-
-    cat > /etc/init.d/yunohost-firstboot << EOF
-#!/bin/sh
-### BEGIN INIT INFO
-# Provides: expand rootfs and Generates new ssh host keys on first boot
-# Required-Start: \$remote_fs \$syslog
-# Required-Stop: \$remote_fs \$syslog
-# Default-Start: 2 3 4 5
-# Default-Stop:
-# Short-Description: Generates new ssh host keys on first boot
-# Description: Generates apt-get --purge clean new ssh host keys on $
-### END INIT INFO
-echo "Expanding rootfs ..."
-raspi-config --expand-rootfs
-echo "Removing myself ..."
-insserv -r /etc/init.d/yunohost-firstboot
-rm -f /etc/init.d/yunohost-firstboot
-rm /etc/yunohost/firstboot
-echo "Rebooting ..."
-reboot
-EOF
-    chmod a+x /etc/init.d/yunohost-firstboot
-    insserv /etc/init.d/yunohost-firstboot
-    touch /etc/yunohost/firstboot
-}
-
-function clean_image() {
-    # Delete SSH keys
-    rm -f /etc/ssh/ssh_host_* >> $YUNOHOST_LOG 2>&1
-    yes | ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa >> $YUNOHOST_LOG 2>&1
-    yes | ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa >> $YUNOHOST_LOG 2>&1
-    yes | ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa -b 521 >> $YUNOHOST_LOG 2>&1
-
-    # Deleting logs ...
-    find /var/log -type f -exec rm {} \; >> $YUNOHOST_LOG 2>&1
-
-    # Purging apt ...
-    apt-get --purge clean >> $YUNOHOST_LOG 2>&1
-}
-
 function post_install() {
     # No postinstall in auto mode
     [[ "$AUTOMODE" == "1" ]] && return 0
@@ -498,5 +432,75 @@ Do you want to try again now?
     done
     return 0
 }
+
+###############################################################################
+# Raspbian specific stuff                                                     #
+###############################################################################
+
+function is_raspbian() {
+    # On Raspbian image lsb_release is available
+    if [[ "$(lsb_release -i -s 2> /dev/null)" != "Raspbian" ]] ;
+    then
+        return 1
+    fi
+    return 0
+}
+
+function user_pi_logged_out() {
+    who | grep pi > /dev/null && return 1
+    return 0
+}
+
+function del_user_pi() {
+    deluser --remove-all-files pi >> $YUNOHOST_LOG 2>&1
+}
+
+function setup_firstboot() {
+
+    cat > /etc/init.d/yunohost-firstboot << EOF
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides: expand rootfs and Generates new ssh host keys on first boot
+# Required-Start: \$remote_fs \$syslog
+# Required-Stop: \$remote_fs \$syslog
+# Default-Start: 2 3 4 5
+# Default-Stop:
+# Short-Description: Generates new ssh host keys on first boot
+# Description: Generates apt-get --purge clean new ssh host keys on $
+### END INIT INFO
+echo "Expanding rootfs ..."
+raspi-config --expand-rootfs
+echo "Removing myself ..."
+insserv -r /etc/init.d/yunohost-firstboot
+rm -f /etc/init.d/yunohost-firstboot
+rm /etc/yunohost/firstboot
+echo "Rebooting ..."
+reboot
+EOF
+    chmod a+x /etc/init.d/yunohost-firstboot
+    insserv /etc/init.d/yunohost-firstboot
+    touch /etc/yunohost/firstboot
+}
+
+###############################################################################
+# Image building specific stuff                                               #
+###############################################################################
+
+function clean_image() {
+    # Delete SSH keys
+    rm -f /etc/ssh/ssh_host_* >> $YUNOHOST_LOG 2>&1
+    yes | ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa >> $YUNOHOST_LOG 2>&1
+    yes | ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa >> $YUNOHOST_LOG 2>&1
+    yes | ssh-keygen -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa -b 521 >> $YUNOHOST_LOG 2>&1
+
+    # Deleting logs ...
+    find /var/log -type f -exec rm {} \; >> $YUNOHOST_LOG 2>&1
+
+    # Purging apt ...
+    apt-get --purge clean >> $YUNOHOST_LOG 2>&1
+}
+
+
+###############################################################################
 
 main

--- a/install_yunohost
+++ b/install_yunohost
@@ -98,7 +98,6 @@ function main()
 
     if is_raspbian ; then
         step del_user_pi     || die "Unable to delete user pi"
-        step change_hostname || die "Unable to change hostname"
         step setup_firstboot || die "Unable to setup firstboot"
     fi
 
@@ -398,11 +397,6 @@ function restart_services() {
 
 function del_user_pi() {
     deluser --remove-all-files pi >> $YUNOHOST_LOG 2>&1
-}
-
-function change_hostname() {
-    sed -i 's/raspberrypi/yunohost/g' /etc/hosts
-    sed -i 's/raspberrypi/yunohost/g' /etc/hostname
 }
 
 function setup_firstboot() {


### PR DESCRIPTION
This is an attempt to clean and improve the install script.

In particular, for the following  : 
- Simplify the syntax for handling step exception (instead of `if ! step foo; then die "bar" fi`, just do `step foo || die "bar"`) ;
- Centralize 'assertions check', such as being on the right debian distribution, to immediately identify problematic situation before running anything else ;
- Wrap everything in function. This is for defensive bash, but also in the optic of moving to a `curl | bash` instruction, we need to avoid the case where the `curl` ends up in the middle of the request, but still dumps half the script and we get weirdly corrupted installs ;
- Improve message logging cosmetics, and other misc cleaning / reorganization ;
- Following some user feedback, detect apache2 and bind9 which might be conflict with nginx and dnsmasq. Provide an option to force the install if the user knows what it's doing ;

As discussed in https://dev.yunohost.org/issues/525 , one of the goal is also to move towards a simple `curl https://install.yunohost.org | bash` install procedure (and provide more cautious instructions for people willing to check integrity / authenticity..). In particular, we should also be able to move step 3 (= check that root has password - not sure why it's necessary) as a check inside the script.