### PR TITLE
Changed pi user log in to exact match

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -461,7 +461,7 @@ function is_raspbian() {
 }
 
 function user_pi_logged_out() {
-    who | grep pi > /dev/null && return 1
+    who | grep -w pi > /dev/null && return 1
     return 0
 }
 


### PR DESCRIPTION
I have an user coldpi and the script would fail without the -w flag because it thinks coldpi is pi.