### PR TITLE
[fix] Ask user for keeping or not sshd config

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -305,35 +305,34 @@ function manage_sshd_config() {
     [[ ! -f /etc/ssh/sshd_config ]] && return 0
     
     local sshd_config_differs="0"
-    local text="To ensure a global security of your server, YunoHost recommends to let it manage the SSH configuration of your server.
-
-Your current SSH configuration differs from common default configuration. If you let YunoHost reconfigure it, the way to access with SSH to your server could change after postinstall:
-"
+    local text="To improve the security of your server, it is recommended to let YunoHost manage the SSH configuration.
+Your current SSH configuration differs from the recommended configuration. 
+If you let YunoHost reconfigure it, the way you connect to your server through SSH will change in the following way:"
 
     # If root login is not deactivate
     if ! grep -E "^[[:blank:]]*PermitRootLogin[[:blank:]]+no" /etc/ssh/sshd_config ; then
         sshd_config_differs="1"
-        text="$text- you will not be able to connect with root user, instead you will have to use admin user.
+        text="$text- you will not be able to connect as root through SSH. Instead you should use the admin user ;
 "
     fi
     
     # If we are using an other Port
     if grep -Ev "^[[:blank:]]*Port[[:blank:]]+22[[:blank:]]*(#.*)?$" /etc/ssh/sshd_config | grep -E "^[[:blank:]]*Port[[:blank:]]+[[:digit:]]+$" ; then
         sshd_config_differs="1"
-        text="$text- you will have to connect using port 22 instead of your custom SSH port. Feel free to reconfigure it after the postinstallation.
+        text="$text- you will have to connect using port 22 instead of your current custom SSH port. Feel free to reconfigure it after the postinstallation.
 "
     fi
 
     # If we are using DSA key for ssh server fingerprint
     if grep -E "^[[:blank:]]*HostKey[[:blank:]]+/etc/ssh/ssh_host_dsa_key" /etc/ssh/sshd_config ; then
         sshd_config_differs="1"
-        text="$text- you might need to invalidate a warning and to recheck fingerprint of your server, because DSA key will be disabled.
+        text="$text- the DSA key will be disabled. Hence, you might need to invalidate a spooky warning from your SSH client, and recheck the fingerprint of your server ;
 "
 
     fi
 
     text="${text}
-Are you agree to let YunoHost replace your configuration and change you way to access your server ?
+Do you agree to let YunoHost apply those changes to your configuration and therefore affect the way you connect through SSH ?
 "
     
     # In all this case we ask user

--- a/install_yunohost
+++ b/install_yunohost
@@ -343,7 +343,7 @@ Do you agree to let YunoHost apply those changes to your configuration and there
 
         # Keep a copy to be restored during the postinstall
         # so that the ssh confs behaves as manually modified.
-        cp /etc/ssh/sshd_config /etc/ssh/sshd_config.to_restore
+        cp /etc/ssh/sshd_config /etc/ssh/sshd_config.before_yunohost
     fi
 
     return 0

--- a/install_yunohost
+++ b/install_yunohost
@@ -311,22 +311,21 @@ Your current SSH configuration differs from common default configuration. If you
 "
 
     # If root login is not deactivate
-    if ! grep -E "^[ \t]*PermitRootLogin[ \t]+no" /etc/ssh/sshd_config ; then
+    if ! grep -E "^[[:blank:]]*PermitRootLogin[[:blank:]]+no" /etc/ssh/sshd_config ; then
         sshd_config_differs="1"
         text="$text- you will not be able to connect with root user, instead you will have to use admin user.
 "
     fi
     
     # If we are using an other Port
-    if ! grep -E "^[ \t]*Port[ \t]+22[ \t]*(#.*)?$" /etc/ssh/sshd_config && \
-        grep -E "^[ \t]*Port[ \t]$" /etc/ssh/sshd_config ; then
+    if grep -Ev "^[[:blank:]]*Port[[:blank:]]+22[[:blank:]]*(#.*)?$" /etc/ssh/sshd_config | grep -E "^[[:blank:]]*Port[[:blank:]]+[[:digit:]]+$" ; then
         sshd_config_differs="1"
         text="$text- you will have to connect using port 22 instead of your custom SSH port. Feel free to reconfigure it after the postinstallation.
 "
     fi
 
     # If we are using DSA key for ssh server fingerprint
-    if grep "^[ \t]*HostKey[ \t]+/etc/ssh/ssh_host_dsa_key" /etc/ssh/sshd_config ; then
+    if grep -E "^[[:blank:]]*HostKey[[:blank:]]+/etc/ssh/ssh_host_dsa_key" /etc/ssh/sshd_config ; then
         sshd_config_differs="1"
         text="$text- you might need to invalidate a warning and to recheck fingerprint of your server, because DSA key will be disabled.
 "

--- a/install_yunohost
+++ b/install_yunohost
@@ -90,6 +90,7 @@ function main()
     step install_script_dependencies   || die "Unable to install dependencies to install script"
     step create_custom_config          || die "Creating custom configuration file /etc/yunohost/yunohost.conf failed"
     step confirm_installation          || die "Installation cancelled at your request"
+    step manage_ssh_config             || die "Error caught during sshd management"
     step fix_locales                   # do not die for a failure here, it's minor
     step setup_package_source          || die "Setting up deb package sources failed"
     step apt_update                    || die "Error caught during 'apt-get update'"
@@ -276,9 +277,6 @@ function install_script_dependencies() {
 function create_custom_config() {
     # Create YunoHost configuration folder
     mkdir -p /etc/yunohost/
-
-    # Store info about installation method
-    touch /etc/yunohost/from_script
 }
 
 function confirm_installation() {
@@ -298,6 +296,62 @@ will be overwritten !
 Are you sure you want  to proceed with the installation of Yunohost?
 "
   whiptail --title "Yunohost Installation" --yesno "$text" 20 78
+}
+
+function manage_sshd_config() {
+    # In auto mode we erase the current sshd config
+    [[ "$AUTOMODE" == "1" ]] && return 0
+
+    [[ ! -f /etc/ssh/sshd_config ]] && return 0
+    
+    local sshd_config_differs = "0"
+    local text="
+Caution !
+
+To ensure a global security of your server, YunoHost recommends to let it manage the SSH configuration of your server.
+
+Your current SSH configuration differs from common default configuration. If you
+let YunoHost reconfigure it, the way to access with SSH to your server could
+change after postinstall:
+"
+
+    # If root login is not deactivate
+    if ! grep -E "^[ \t]*PermitRootLogin[ \t]+no" /etc/ssh/sshd_config ; then
+        sshd_config_differs = "1"
+        text="$text- you will not be able to connect with root user, instead you will have to use admin user.
+"
+    fi
+    
+    # If we are using an other Port
+    if ! grep -E "^[ \t]*Port[ \t]+22[ \t]*(#.*)?$" /etc/ssh/sshd_config && \
+        grep -E "^[ \t]*Port[ \t]$" /etc/ssh/sshd_config ; then
+        sshd_config_differs = "1"
+        text="$text- you will have to connect using port 22 instead of your custom SSH port. Feel free to reconfigure it after the postinstallation.
+"
+    fi
+
+    # If we are using DSA key for ssh server fingerprint
+    if grep "^[ \t]*HostKey[ \t]+/etc/ssh/ssh_host_dsa_key" /etc/ssh/sshd_config ; then
+        sshd_config_differs = "1"
+        text="$text- you might need to invalidate a warning and to recheck fingerprint of your server, because DSA key will be disabled.
+"
+
+    fi
+
+    text="${text} Are you agree to let YunoHost replace your configuration and change you way to access your server ?
+"
+    
+    # In all this case we ask user
+    if [[ "$sshd_config_differs" == "1" ]] ; then
+        if ! whiptail --title "SSH Configuration" --yesno "$text" 20 78 --defaultno ; then
+            
+            # Keep a copy to restore it after regen-conf
+            cp /etc/ssh/sshd_config /etc/ssh/sshd_config.to_restore
+        fi
+    fi
+
+    return 0
+
 }
 
 function setup_package_source() {

--- a/install_yunohost
+++ b/install_yunohost
@@ -90,7 +90,7 @@ function main()
     step install_script_dependencies   || die "Unable to install dependencies to install script"
     step create_custom_config          || die "Creating custom configuration file /etc/yunohost/yunohost.conf failed"
     step confirm_installation          || die "Installation cancelled at your request"
-    step manage_ssh_config             || die "Error caught during sshd management"
+    step manage_sshd_config            || die "Error caught during sshd management"
     step fix_locales                   # do not die for a failure here, it's minor
     step setup_package_source          || die "Setting up deb package sources failed"
     step apt_update                    || die "Error caught during 'apt-get update'"
@@ -304,7 +304,7 @@ function manage_sshd_config() {
 
     [[ ! -f /etc/ssh/sshd_config ]] && return 0
     
-    local sshd_config_differs = "0"
+    local sshd_config_differs="0"
     local text="
 Caution !
 
@@ -317,7 +317,7 @@ change after postinstall:
 
     # If root login is not deactivate
     if ! grep -E "^[ \t]*PermitRootLogin[ \t]+no" /etc/ssh/sshd_config ; then
-        sshd_config_differs = "1"
+        sshd_config_differs="1"
         text="$text- you will not be able to connect with root user, instead you will have to use admin user.
 "
     fi
@@ -325,14 +325,14 @@ change after postinstall:
     # If we are using an other Port
     if ! grep -E "^[ \t]*Port[ \t]+22[ \t]*(#.*)?$" /etc/ssh/sshd_config && \
         grep -E "^[ \t]*Port[ \t]$" /etc/ssh/sshd_config ; then
-        sshd_config_differs = "1"
+        sshd_config_differs="1"
         text="$text- you will have to connect using port 22 instead of your custom SSH port. Feel free to reconfigure it after the postinstallation.
 "
     fi
 
     # If we are using DSA key for ssh server fingerprint
     if grep "^[ \t]*HostKey[ \t]+/etc/ssh/ssh_host_dsa_key" /etc/ssh/sshd_config ; then
-        sshd_config_differs = "1"
+        sshd_config_differs="1"
         text="$text- you might need to invalidate a warning and to recheck fingerprint of your server, because DSA key will be disabled.
 "
 

--- a/install_yunohost
+++ b/install_yunohost
@@ -303,30 +303,30 @@ function manage_sshd_config() {
     [[ "$AUTOMODE" == "1" ]] && return 0
 
     [[ ! -f /etc/ssh/sshd_config ]] && return 0
-    
-    local sshd_config_differs="0"
+
+    local sshd_config_possible_issues="0"
     local text="To improve the security of your server, it is recommended to let YunoHost manage the SSH configuration.
-Your current SSH configuration differs from the recommended configuration. 
+Your current SSH configuration differs from the recommended configuration.
 If you let YunoHost reconfigure it, the way you connect to your server through SSH will change in the following way:"
 
-    # If root login is not deactivate
+    # If root login is currently enabled
     if ! grep -E "^[[:blank:]]*PermitRootLogin[[:blank:]]+no" /etc/ssh/sshd_config ; then
-        sshd_config_differs="1"
-        text="$text- you will not be able to connect as root through SSH. Instead you should use the admin user ;
+        sshd_config_possible_issues="1"
+        text="$text\n- you will not be able to connect as root through SSH. Instead you should use the admin user ;
 "
     fi
-    
-    # If we are using an other Port
+
+    # If current conf uses a custom ssh port
     if grep -Ev "^[[:blank:]]*Port[[:blank:]]+22[[:blank:]]*(#.*)?$" /etc/ssh/sshd_config | grep -E "^[[:blank:]]*Port[[:blank:]]+[[:digit:]]+$" ; then
-        sshd_config_differs="1"
-        text="$text- you will have to connect using port 22 instead of your current custom SSH port. Feel free to reconfigure it after the postinstallation.
+        sshd_config_possible_issues="1"
+        text="$text\n- you will have to connect using port 22 instead of your current custom SSH port. Feel free to reconfigure it after the postinstallation.
 "
     fi
 
     # If we are using DSA key for ssh server fingerprint
     if grep -E "^[[:blank:]]*HostKey[[:blank:]]+/etc/ssh/ssh_host_dsa_key" /etc/ssh/sshd_config ; then
-        sshd_config_differs="1"
-        text="$text- the DSA key will be disabled. Hence, you might need to invalidate a spooky warning from your SSH client, and recheck the fingerprint of your server ;
+        sshd_config_possible_issues="1"
+        text="$text\n- the DSA key will be disabled. Hence, you might later need to invalidate a spooky warning from your SSH client, and recheck the fingerprint of your server ;
 "
 
     fi
@@ -334,18 +334,19 @@ If you let YunoHost reconfigure it, the way you connect to your server through S
     text="${text}
 Do you agree to let YunoHost apply those changes to your configuration and therefore affect the way you connect through SSH ?
 "
-    
-    # In all this case we ask user
-    if [[ "$sshd_config_differs" == "1" ]] ; then
-        if ! whiptail --title "SSH Configuration" --yesno "$text" 20 78 --defaultno --scrolltext ; then
-            
-            # Keep a copy to restore it after regen-conf
-            cp /etc/ssh/sshd_config /etc/ssh/sshd_config.to_restore
-        fi
+
+    # If no possible issue found, we just assume it's okay and will take over the SSH conf during postinstall
+    [[ "$sshd_config_possible_issues" == "0" ]] && return 0
+
+    # Otherwise, we ask the user to confirm
+    if ! whiptail --title "SSH Configuration" --yesno "$text" 20 78 --defaultno --scrolltext ; then
+
+        # Keep a copy to be restored during the postinstall
+        # so that the ssh confs behaves as manually modified.
+        cp /etc/ssh/sshd_config /etc/ssh/sshd_config.to_restore
     fi
 
     return 0
-
 }
 
 function setup_package_source() {

--- a/install_yunohost
+++ b/install_yunohost
@@ -305,14 +305,9 @@ function manage_sshd_config() {
     [[ ! -f /etc/ssh/sshd_config ]] && return 0
     
     local sshd_config_differs="0"
-    local text="
-Caution !
+    local text="To ensure a global security of your server, YunoHost recommends to let it manage the SSH configuration of your server.
 
-To ensure a global security of your server, YunoHost recommends to let it manage the SSH configuration of your server.
-
-Your current SSH configuration differs from common default configuration. If you
-let YunoHost reconfigure it, the way to access with SSH to your server could
-change after postinstall:
+Your current SSH configuration differs from common default configuration. If you let YunoHost reconfigure it, the way to access with SSH to your server could change after postinstall:
 "
 
     # If root login is not deactivate
@@ -338,12 +333,13 @@ change after postinstall:
 
     fi
 
-    text="${text} Are you agree to let YunoHost replace your configuration and change you way to access your server ?
+    text="${text}
+Are you agree to let YunoHost replace your configuration and change you way to access your server ?
 "
     
     # In all this case we ask user
     if [[ "$sshd_config_differs" == "1" ]] ; then
-        if ! whiptail --title "SSH Configuration" --yesno "$text" 20 78 --defaultno ; then
+        if ! whiptail --title "SSH Configuration" --yesno "$text" 20 78 --defaultno --scrolltext ; then
             
             # Keep a copy to restore it after regen-conf
             cp /etc/ssh/sshd_config /etc/ssh/sshd_config.to_restore


### PR DESCRIPTION
## The problem

Some instance don't use the sshd conf of YunoHost.

## Solution

Ask user what he wants do instead of disable the conf management with a dangerous from_script file.
## PR Status
Ready
Related PR https://github.com/YunoHost/yunohost/pull/518

## How to test
On a debian 
Install openssh-server
Make some change in config
Run this script

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 