### PR TITLE
Set whiptail colors to black and white instead of ugly blue and gry ?

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -21,6 +21,17 @@ set -u
 
 readonly YUNOHOST_LOG="/var/log/yunohost-installation_$(date +%Y%m%d_%H%M%S).log"
 
+# Custom colors for whiptail
+export NEWT_COLORS='
+root=white,black
+roottext=white,black
+window=white,black
+border=white,black
+title=white,black
+textbox=white,black
+button=black,white
+'
+
 ###############################################################################
 # Main functions                                                              #
 ###############################################################################


### PR DESCRIPTION
This is a purely arbitrary cosmetic change to use a black and white which I find more elegant than the default ugly blue and grey (though maybe that's supposed to improve accessibility ? idk ...)

![2018-11-29-175430_1366x768_scrot](https://user-images.githubusercontent.com/4533074/49238259-551de500-f400-11e8-8207-a71a6be9ac56.png)
