### PR TITLE
Remove postinstall and instead print a text explaining what to do and pointing to the documentation

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -111,10 +111,9 @@ function main()
         reboot
     fi
 
-    step post_install || die "Post-installation failed"
-
     info "Installation logs are available in $YUNOHOST_LOG"
     success "YunoHost installation completed !"
+    conclusion
     exit 0
 }
 
@@ -417,51 +416,25 @@ function fix_locales() {
     export LC_ALL
 }
 
-function post_install() {
-    # No postinstall in auto mode
-    [[ "$AUTOMODE" == "1" ]] && return 0
+function conclusion() {
+    cat << EOF
+===============================================================================
+You should now proceed with Yunohost post-installation. This is where you will
+be asked for :
+- the main domain of your server ;
+- the administration password.
 
-    # Remove whiptail and dialog remains...
-    clear
+You can perform this step :
+- from the command line, by running 'yunohost tools postinstall' as root
+- or from your web browser, by accessing https://11.22.33.44 (replacing the
+numbers with your server's local or global IP).
 
-    local text="
-Yunohost packages have been installed successfully!
-
-You can now proceed with Yunohost post-installation.
-This is where you will be asked for :
-- the main DNS domain name of your server
-- the administration password
-
-You can also perform this step later on your own :
-- either from a shell, by running 'yunohost tools postinstall'
-  as root
-- either from your web browser, by accessing https://yunohost.local
-
-Please refer to https://yunohost.org/#/postinstall
-for additionnal information.
-
-Do you want to proceed with YunoHost post-installation now?
-"
-    whiptail --title "Post-installation" --yesno "$text" 25 78 \
-        || return 0
-
-    /usr/bin/yunohost tools postinstall
-
-    local POSTINSTALL_EXIT_CODE="$?"
-    while [[ "$POSTINSTALL_EXIT_CODE" != "0" ]] ;
-    do
-        local text_retry="
-Yunohost post-installation has failed.
-
-Do you want to try again now?
-"
-        whiptail --title "Post-installation" --yesno "$text_retry" 12 78 --defaultno \
-            || return $POSTINSTALL_EXIT_CODE
-
-        /usr/bin/yunohost tools postinstall
-        POSTINSTALL_EXIT_CODE="$?"
-    done
-    return 0
+If this is your first time with YunoHost, it is strongly advised to take time
+to read the administator documentation and in particular the sections
+'Finalizing your setup' and 'Getting to know YunoHost'. It is available at the
+following URL : https://yunohost.org/admindoc
+===============================================================================
+EOF
 }
 
 ###############################################################################

--- a/install_yunohost
+++ b/install_yunohost
@@ -432,17 +432,17 @@ function conclusion() {
 ===============================================================================
 You should now proceed with Yunohost post-installation. This is where you will
 be asked for :
-- the main domain of your server ;
-- the administration password.
+  - the main domain of your server ;
+  - the administration password.
 
 You can perform this step :
-- from the command line, by running 'yunohost tools postinstall' as root
-- or from your web browser, by accessing : ${local_ip}${global_ip}
+  - from the command line, by running 'yunohost tools postinstall' as root
+  - or from your web browser, by accessing : ${local_ip}${global_ip}
 
-If this is your first time with YunoHost, it is strongly advised to take time
-to read the administator documentation and in particular the sections
-'Finalizing your setup' and 'Getting to know YunoHost'. It is available at the
-following URL : https://yunohost.org/admindoc
+If this is your first time with YunoHost, it is strongly recommended to take
+time to read the administator documentation and in particular the sections
+'Finalizing your setup' and 'Getting to know YunoHost'. It is available at
+the following URL : https://yunohost.org/admindoc
 ===============================================================================
 EOF
 }

--- a/install_yunohost
+++ b/install_yunohost
@@ -417,6 +417,17 @@ function fix_locales() {
 }
 
 function conclusion() {
+    # Get first local IP and global IP
+    local local_ip=$(hostname --all-ip-address | awk '{print $1}')
+    local global_ip=$(curl https://ip.yunohost.org 2>/dev/null)
+
+    # Will ignore local ip if it's already the global IP (e.g. for some VPS)
+    [[ "$local_ip" != "$global_ip" ]] || local_ip=""
+
+    # Formatting
+    [[ -z "$local_ip" ]] || local_ip=$(echo -e "\n    - https://$local_ip/ (local IP, if self-hosting at home)")
+    [[ -z "$global_ip" ]] || global_ip=$(echo -e "\n    - https://$global_ip/ (global IP, if you're on a VPS)")
+
     cat << EOF
 ===============================================================================
 You should now proceed with Yunohost post-installation. This is where you will
@@ -426,8 +437,7 @@ be asked for :
 
 You can perform this step :
 - from the command line, by running 'yunohost tools postinstall' as root
-- or from your web browser, by accessing https://11.22.33.44 (replacing the
-numbers with your server's local or global IP).
+- or from your web browser, by accessing : ${local_ip}${global_ip}
 
 If this is your first time with YunoHost, it is strongly advised to take time
 to read the administator documentation and in particular the sections


### PR DESCRIPTION
This proposes to remove the postinstall being proposed / triggered at the end of the install script.
Motivations behind this is : 
- simplify the command line. Currently we have to run `bash <(wget the_url)` instead of `bash the_url | curl` because bash needs access to stdin only for the postinstall that might be run ;
- imho there's little gain in triggering this from the install script rather than asking the user to do it from the web admin or the cli (so that the admin discovers one or the other rather than the install script masking it ?) ;
- if the postinstall fails during the install script, it's not easy to debug :|, c.f. https://github.com/YunoHost/issues/issues/1166
- we should point at the documentation more often and that's a good occasion to do so ?