### PR TITLE
Use a trick to avoid grub config prompt

### DIFF
--- a/install_yunohost
+++ b/install_yunohost
@@ -252,6 +252,15 @@ function upgrade_system() {
                     libtext-iconv-perl                   \
     || return 1
 
+    # Manually upgrade grub stuff in non-interactive mode,
+    # otherwise a weird technical question is asked to the user
+    # regarding how to upgrade grub's configuration...
+    DEBIAN_FRONTEND=noninteractive \
+    apt_get_wrapper -o Dpkg::Options::="--force-confold" \
+                    -y install --only-upgrade \
+                    grub-common grub2-common \
+    || true
+
     apt_get_wrapper -o Dpkg::Options::="--force-confold" \
                     -y dist-upgrade \
     || return 2

--- a/install_yunohost
+++ b/install_yunohost
@@ -252,7 +252,8 @@ function upgrade_system() {
                     libtext-iconv-perl                   \
     || return 1
 
-    apt_get_wrapper -y dist-upgrade \
+    apt_get_wrapper -o Dpkg::Options::="--force-confold" \
+                    -y dist-upgrade \
     || return 2
 
     if is_raspbian ; then


### PR DESCRIPTION
Currently there's a small issue where, during the initial dist-upgrade at the beginning of the install script, apt might end up asking technical questions about which version to keep for grub's conf file (or something else, i don't remember exactly what)

This happens for instance on Scaleway instances.

This small patch should fix it though I havent tested it yet.