### PR TITLE
Buster: Die if IPV6 module is not loaded

### DIFF
--- a/buster
+++ b/buster
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2015-2020 YunoHost
+# Copyright (C) 2015-2021 YunoHost
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -233,6 +233,11 @@ function check_assertions()
 
     # Assert systemd is installed
     command -v systemctl > /dev/null || die "YunoHost requires systemd to be installed."
+
+    if [[ $(cat /sys/module/ipv6/parameters/disable) == "1" ]];
+    then
+    	die "The package 'redis-server' will fail to install without IPV6 enabled."
+    fi
 
     # Check that kernel is >= 3.12, otherwise systemd won't work properly. Cf. https://github.com/systemd/systemd/issues/5236#issuecomment-277779394
     dpkg --compare-versions "$(uname -r)" "ge" "3.12" || die "YunoHost requires a kernel >= 3.12. Please consult your hardware documentation or VPS provider to learn how to upgrade your kernel."


### PR DESCRIPTION
When installing YunoHost on Debian Buster, `redis-server` failed to install since I had not enabled IPV6. (See https://github.com/YunoHost/issues/issues/1915)

Here's a (at least primary) way to hopefully prevent the same unhelpful output I was getting