### PR TITLE
Allow both unstable and testing

### DIFF
--- a/bookworm
+++ b/bookworm
@@ -236,7 +236,7 @@ function check_assertions()
 {
     if [[ $DISTRIB == "stable" ]]
     then
-        error "Only unstable and testing branches are supported for Bookworm right now. We ABSOLUTELY DISCOURAGE using YunoHost Bookworm in any sort of production setup right now. Everything is in BETA STAGE ONLY."
+        error "Only unstable and testing branches are supported for Bookworm right now. We ABSOLUTELY DISCOURAGE using YunoHost Bookworm in any sort of production setup right now UNLESS YOU ARE A POWER-USER. Everything is in BETA STAGE ONLY."
         return 1
     fi
 

--- a/bookworm
+++ b/bookworm
@@ -234,9 +234,9 @@ function apt_install() {
 
 function check_assertions()
 {
-    if [[ $DISTRIB != "unstable" ]]
+    if [[ $DISTRIB == "stable" ]]
     then
-        error "Only unstable branch is supported for Bookworm right now. We ABSOLUTELY DISCOURAGE using YunoHost Bookworm in any sort of production (or even testing) setup right now. Everything is in PRE-ALPHA STAGE ONLY."
+        error "Only unstable and testing branches are supported for Bookworm right now. We ABSOLUTELY DISCOURAGE using YunoHost Bookworm in any sort of production setup right now. Everything is in BETA STAGE ONLY."
         return 1
     fi
 


### PR DESCRIPTION
Bookworm is now in Beta stage, so I guess we can allow the testing branch too (I need that to be able to rebuild both ynhci and appci images)