### PR TITLE
fix(apt): explicitely install yunohost-portal

### DIFF
--- a/trixie
+++ b/trixie
@@ -650,8 +650,8 @@ EOF
     # Install YunoHost
     # FIXME : do we still want to install recommends ?
     apt_install                              \
-        -o APT::install-recommends=true      \
-        yunohost yunohost-admin postfix
+        -o APT::Install-Recommends="true"    \
+        yunohost yunohost-admin yunohost-portal postfix
 }
 
 function conclusion() {


### PR DESCRIPTION
*During YunoCamp 2026*

Armbian now has a default configuration for apt where they disable the installation of the recommended and suggested dependencies.

Also attempt to fix the command line config for said recommended dependencies.